### PR TITLE
Add Pullquote functionality to the Slash theme

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,4 +1,5 @@
 @import "base/color";
 @import "base/font";
 @import "base/layout";
+@import "base/typography";
 @import "base/utilities";

--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -1,0 +1,26 @@
+.pullquote-right:before,
+.pullquote-left:before {
+  /* Reset metrics. */
+  padding: 0;
+  border: none;
+
+  /* Content */
+  content: attr(data-pullquote);
+
+  /* Pull out to the right, modular scale based margins. */
+  float: right;
+  width: 45%;
+  margin: .5em 0 1em 1.5em;
+
+  /* Baseline correction */
+  position: relative;
+  top: 7px;
+  font-size: 1.4em;
+  line-height: 1.45em;
+}
+
+.pullquote-left:before {
+  /* Make left pullquotes align properly. */
+  float: left;
+  margin: .5em 1.5em 1em 0;
+}


### PR DESCRIPTION
Pullquote functionality is built into the classic Octopress theme and supported by the pullquote.rb plugin.

This pull request creates a _typography.scss file in the base folder which provides the SASS needed to make pullquotes work.

A [demo](http://make.bettermistak.es/new-page) can be seen on my website. 
