### PR TITLE
Correct the author in the copyright footer

### DIFF
--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -1,1 +1,6 @@
-Copyright &copy; {{ site.time | date: "%Y" }} {{ site.author }}
+Copyright &copy; {{ site.time | date: "%Y" }}
+{% if site.author %}
+    {{ site.author }}
+{% else %}
+    {{ site.title }}
+{% endif %}


### PR DESCRIPTION
In the copyright footer, `site.author` should be used instead of `site.title`.
