### PR TITLE
"page.footer" to control the display of footer

### DIFF
--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -8,7 +8,9 @@ layout: default
     {% endif %}
     <div class="entry">{{ content }}</div>
 </article>
-{% include post/sharing.html %}
+{% unless page.footer == false %}
+    {% include post/sharing.html %}
+{% endunless %}
 {% if site.disqus_short_name and page.comments == true %}
 <section id="comment">
     <h1 class="title">Comments</h1>


### PR DESCRIPTION
In page layout pages, we could use page.footer to control whether to
display the footer.

Just like the [classic theme](https://github.com/imathis/octopress/blob/9f40242b1e7eb0098f0ef3c508c7bed7e647b982/.themes/classic/source/_layouts/page.html#L14) does.
