### PR TITLE
Add author info for the Google plus link.

### DIFF
--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -21,7 +21,7 @@
 		<a class="facebook" href="http://www.facebook.com/{{ site.facebook_user }}" title="Facebook">Facebook</a>
 		{% endif %}
 		{% if site.googleplus_user and site.googleplus_hidden == false %}
-		<a class="google" href="https://plus.google.com/{{ site.googleplus_user }}" title="Google+">Google+</a>
+		<a class="google" href="https://plus.google.com/{{ site.googleplus_user }}?rel=author" title="Google+">Google+</a>
 		{% endif %}
 		{% if site.twitter_user %}
 		<a class="twitter" href="http://twitter.com/{{ site.twitter_user }}" title="Twitter">Twitter</a>


### PR DESCRIPTION
According to [this page](http://support.google.com/webmasters/bin/answer.py?hl=en&answer=1408986), if the link to the Google Plus Profile does not contain `?rel=author`, the Google search result will not show the web page author info. Now added.
