### PR TITLE
Normalized the elements used in div.meta

### DIFF
--- a/source/_includes/archive_post.html
+++ b/source/_includes/archive_post.html
@@ -10,10 +10,10 @@
 <article>
 	<h2 class="title"><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h2>
 	<div class="meta">
-		<span class="date">{{ date | date: "%b %e" }}</span>
-		<span class="tags">{% include post/categories.html %}</span>
+		<div class="date">{{ date | date: "%b %e" }}</div>
+		<div class="tags">{% include post/categories.html %}</div>
 	    {% if site.disqus_short_name and post.comments == true and site.disqus_show_comment_count == true %}
-	    <span class="comments"><a href="{{ root_url }}{{ post.url }}#disqus_thread">Comments</a></span>
+	    <div class="comments"><a href="{{ root_url }}{{ post.url }}#disqus_thread">Comments</a></div>
 	    {% endif %}
 	</div>
 </article>

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -21,6 +21,6 @@
 	<div class="date">{% include post/date.html %}{{ time }}</div>
 	<div class="tags">{% include post/categories.html %}</div>
 	{% if site.disqus_short_name and site.disqus_show_comment_count == true %}
-		<span class="comments"><a href="{{ root_url }}{{ post.url }}{{ page.url }}#disqus_thread">Comments</a></span>
+		<div class="comments"><a href="{{ root_url }}{{ post.url }}{{ page.url }}#disqus_thread">Comments</a></div>
 	{% endif %}
 </div>


### PR DESCRIPTION
In some places, the `.meta` div contained divs and spans, and in other places contained only spans. When longer strings appeared in the spans, they would overflow like this:
![](http://f.cl.ly/items/1C2L3W1l0h3n322S2p0o/Screen%20Shot%202013-02-10%20at%207.09.23%20PM.png)

and this:
![](http://f.cl.ly/items/2o3x3q3Y260f34380j2s/Screen%20Shot%202013-02-10%20at%207.10.51%20PM.png)

Changing the spans to divs fixes this and cause text to wrap nicely, as seen here:
![](http://f.cl.ly/items/270z050q3t2P1j3E0Q0g/Screen%20Shot%202013-02-10%20at%207.12.45%20PM.png)

Thanks!
