### PR TITLE
Import custom style overrides

### DIFF
--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -5,3 +5,5 @@
 @import "base";
 @import "parts";
 @import "plugins";
+
+@import "custom/styles";


### PR DESCRIPTION
The default Octopress theme imports a custom scss file at the end of its
screen.scss file that allows for people to override a theme's styles
with their own, custom styling. This commit takes that cue and
implements it for the Slash theme, importing the same file to allow for
overrides, making the theme more flexible.

More information on the default theme's custom style capabilities can be
found at:

  http://octopress.org/docs/theme/styles/
