### PR TITLE
Strip HTML from page title in title tag

### DIFF
--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+	<title>{% if page.title %}{{ page.title | strip_html }} - {% endif %}{{ site.title }}</title>
 	<meta name="author" content="{{ site.author }}">
 
 	{% capture description %}{% if page.description %}{{ page.description }}{% else %}{{ content | raw_content }}{% endif %}{% endcapture %}


### PR DESCRIPTION
When the title of a post contained HTML, it was appearing in the title
tag as escaped html, which doesn't read very well for most people.
Stripping the HTML from page titles when used in the title tag makes
this a little nicer.
