### PR TITLE
Use `h1` elements for post and page titles

### DIFF
--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -17,7 +17,7 @@ $header-height: 30px;
 			color: $color-main;
 		}
 	}
-	h1{
+	#site-title{
 		float: left;
 		font-weight: 300;
 		font-size: 30px;

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -13,7 +13,7 @@
 		{% if excerpted == 'true' %}<a href="{{ root_url }}{{ post.url }}" class="more-link">{{ site.excerpt_link }}</a>{% endif %}
 	</div>
 {% else %}
-	<h2 class="title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h2>
+	<h1 class="title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
 	<div class="entry-content">{{ content }}</div>
 {% endif %}
 

--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -1,4 +1,4 @@
-<h1><a href="{{ root_url }}/">{{ site.title }}</a></h1>
+<div id="site-title"><a href="{{ root_url }}/">{{ site.title }}</a></div>
 <nav id="main-nav">{% include navigation.html %}</nav>
 <nav id="mobile-nav">
 	<div class="alignleft menu">


### PR DESCRIPTION
The `h1` element serves as a signal that machines have been told to
interpret as "this is what this page is all about", similarly to the
`title` tag. Since each page should be unique and have a distinct
purpose, putting the site title in an `h1` on every single page is not
ideal. We'd rather be be giving these machines a clearer signal as to
what our pages are about.

This commit changes the element used for the site title from an `h1`
element to a plain `div`, and bumps the post and page titles from `h2`
to `h1`. This has the added bonus of improving the hierarchy of headings
in the posts themselves, which are likely to start at `h2`.

This should improve search engine optimization as well as integration
with other third-party services, such as Readability.
