### PR TITLE
Fixed malformed disqus comments urls in index

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -21,6 +21,6 @@
 	<div class="date">{% include post/date.html %}{{ time }}</div>
 	<div class="tags">{% include post/categories.html %}</div>
 	{% if site.disqus_short_name and site.disqus_show_comment_count == true %}
-		<div class="comments"><a href="{{ root_url }}{{ post.url }}{{ page.url }}#disqus_thread">Comments</a></div>
+	<div class="comments"><a href="{{ root_url }}{% if index %}{{ post.url }}{% endif %}#disqus_thread">Comments</a></div>
 	{% endif %}
 </div>


### PR DESCRIPTION
Adding the page.url tag malformed the comment link url when generating the index. This is just a aesthetic fix since adding "/index.html" to the url still pointed to the comments although it is refering to the index itself. 
