### PR TITLE
fix position of section element, when article is just one.

### DIFF
--- a/source/_includes/archive_post.html
+++ b/source/_includes/archive_post.html
@@ -6,9 +6,6 @@
 		</section>
 	{% endunless %}
 	<section class="archives"><h1 class="year">{{ date | date: "%Y" }}</h1>
-	{% if forloop.last %}
-	</section>
-	{% endif %}
 {% endunless %}
 <article>
 	<h2 class="title"><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h2>
@@ -20,3 +17,6 @@
 	    {% endif %}
 	</div>
 </article>
+	{% if forloop.last %}
+	</section>
+	{% endif %}


### PR DESCRIPTION
I found a little bit wrong of template.

When it is only a article on the Archives or the Category, The template is broken.
