### PR TITLE
Fixed date template

### DIFF
--- a/source/_includes/post/date.html
+++ b/source/_includes/post/date.html
@@ -1,15 +1,5 @@
-{% capture date %}{{ page.date }}{{ post.date }}{% endcapture %}
-{% capture date_formatted %}{{ page.date_formatted }}{{ post.date_formatted }}{% endcapture %}
-{% capture has_date %}{{ date | size }}{% endcapture %}
+{% if page.date %}{% capture time %}{{ page.date_text }}{% endcapture %}{% endif %}
+{% if post.date %}{% capture time %}{{ post.date_text }}{% endcapture %}{% endif %}
 
-{% capture updated %}{{ page.updated }}{{ post.updated }}{% endcapture %}
-{% capture updated_formatted %}{{ page.updated_formatted }}{{ post.updated_formatted }}{% endcapture %}
-{% capture was_updated %}{{ updated | size }}{% endcapture %}
-
-{% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
-{% endif %}
-
-{% if was_updated != '0' %}
-  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated">Updated {{ updated_formatted }}</time>{% endcapture %}
-{% else %}{% assign updated = false %}{% endif %}
+{% if page.updated %}{% capture updated %}{{ page.date_updated_text }}{% endcapture %}{% endif %}
+{% if post.updated %}{% capture updated %}{{ post.date_updated_text }}{% endcapture %}{% endif %}


### PR DESCRIPTION
With the new octopress-date-time gem there is a significant difference how the date-time should be displayed. Using old template results with no date displayed.
